### PR TITLE
Fixed typo in Klarna doc referencing Square

### DIFF
--- a/content/payment-providers/klarna/0.1.0/klarna-hpp/getting-started/configuring-umbraco.md
+++ b/content/payment-providers/klarna/0.1.0/klarna-hpp/getting-started/configuring-umbraco.md
@@ -11,7 +11,7 @@ In the Umbraco back-office, in the **Settings > Vendr > Stores > {Store Name} > 
 
 ## Configure Payment Provider Settings
 
-In the payment method editor, configure the standard payment method settings as required, then configure the Square payment provider settings as follows:
+In the payment method editor, configure the standard payment method settings as required, then configure the Klarna payment provider settings as follows:
 
 | Name | Description |
 | ---- | ----------- |


### PR DESCRIPTION
Fixed reference to Square checkout in Klarna documentation